### PR TITLE
Add element-plus w/ npm auto-update

### DIFF
--- a/packages/e/element-plus.json
+++ b/packages/e/element-plus.json
@@ -1,0 +1,46 @@
+{
+  "name": "element-plus",
+  "filename": "index.full.js",
+  "description": "A Vue.js 3.0 UI Library made by Element team",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/element-plus/element-plus.git"
+  },
+  "license": "MIT",
+  "homepage": "https://element-plus.org",
+  "keywords": [
+    "vuejs",
+    "vue3",
+    "vue",
+    "element-ui",
+    "component-library",
+    "vue-composition-api"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "element-plus",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "theme-chalk/index.css",
+          "index.full.js"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "zazzaz"
+    },
+    {
+      "name": "JeremyWuuuuu"
+    },
+    {
+      "name": "Ryan2128"  
+    },
+    {
+      "name": "HerringtonDarkholme"
+    }
+  ]
+}


### PR DESCRIPTION
### New package cdn support
From staticfile's user request https://github.com/staticfile/static/issues/602
`cdnjs` is staticfile's upstream, we can only create new `PR` to `cdnjs` to support `element-plus` cdn feature. 

### File match pattern
> https://element-plus.org/#/en-US/component/installation

The official cdn usage.

![2021-04-22 15 28 49](https://user-images.githubusercontent.com/14012511/115673644-725fff00-a37f-11eb-959f-aa54d4e0338d.png)

So i only write two explicit file name
```diff
+         "theme-chalk/index.css",
+         "index.full.js"
```
Will we change the build path  in the future? Is explicit match pattern enough ? 
/cc @JeremyWuuuuu @kooriookami @justwiner @zazzaz (active  `element-plus` maintainer)

### Code Review
/cc @MattIPv4  (cdnjs maintainer)

### Appended
My opioion is current config is enough, the `index.full.js` is `UMD` mode, we can update the `element-plus.json` in the future if the build artifacts changed. The `cdnjs` page will show the user needed file cleanly.

